### PR TITLE
Rename merge requests title to 'Merge Requests'

### DIFF
--- a/src/info.plist
+++ b/src/info.plist
@@ -285,7 +285,7 @@
 				<key>fixedorder</key>
 				<false/>
 				<key>items</key>
-				<string>[{"title":"Pipelines","arg":"pipelines"},{"title":"Overview"},{"title":"Issues","arg":"issues"},{"title":"Merge Request","arg":"merge_requests"}]</string>
+				<string>[{"title":"Pipelines","arg":"pipelines"},{"title":"Overview"},{"title":"Issues","arg":"issues"},{"title":"Merge Requests","arg":"merge_requests"}]</string>
 				<key>runningsubtext</key>
 				<string></string>
 				<key>subtext</key>


### PR DESCRIPTION
I think the title should be name `Merge Requests` as it's also like this on GitLab.