### PR TITLE
More guidance on setting custom URL and Token

### DIFF
--- a/src/info.plist
+++ b/src/info.plist
@@ -386,7 +386,7 @@
 				<key>keyword</key>
 				<string>glsetkey</string>
 				<key>subtext</key>
-				<string>Enter your GitLab Private Token and hit ENTER</string>
+				<string>Set your GitLab Private Token, should be 20 random characters</string>
 				<key>text</key>
 				<string>Set your GitLab Private Token</string>
 				<key>withspace</key>
@@ -453,7 +453,7 @@
 				<key>keyword</key>
 				<string>glseturl</string>
 				<key>subtext</key>
-				<string>Enter your GitLab URL and hit ENTER</string>
+				<string>Set your GitLab URL, e.g. https://gitlab.example.com/api/v4/projects</string>
 				<key>text</key>
 				<string>Set your GitLab URL</string>
 				<key>withspace</key>


### PR DESCRIPTION
I always have to refer to the Readme to correctly set the custom URL

![image](https://user-images.githubusercontent.com/697301/61276213-de2b3600-a7af-11e9-9995-3784f1dabed4.png)

Partial solution for https://github.com/lukewaite/alfred-gitlab/issues/10 :) 

Had to change "Enter X and hit Enter" to "Set" so it will fill into the Alfred window ¯\_(ツ)_/¯

Thx for awesome workflow
