### PR TITLE
Add support for default issue board

### DIFF
--- a/src/info.plist
+++ b/src/info.plist
@@ -285,7 +285,7 @@
 				<key>fixedorder</key>
 				<false/>
 				<key>items</key>
-				<string>[{"title":"Pipelines","arg":"pipelines"},{"title":"Overview"},{"title":"Issues","arg":"issues"},{"title":"Merge Request","arg":"merge_requests"}]</string>
+				<string>[{"title":"Pipelines","arg":"pipelines"},{"title":"Overview"},{"title":"Issues","arg":"issues"},{"title":"Merge Request","arg":"merge_requests"},{"title":"Default Issue Board","arg":"-/boards"}]</string>
 				<key>runningsubtext</key>
 				<string></string>
 				<key>subtext</key>


### PR DESCRIPTION
`Default Issue Board` will open the default issue board of your gitlab project:

![image](https://user-images.githubusercontent.com/7387295/73874203-58f29600-4853-11ea-818b-5b87e7579b96.png)
