### PR TITLE
feat: add Headers for api call

### DIFF
--- a/src/update.py
+++ b/src/update.py
@@ -12,7 +12,8 @@ def get_projects(api_key, url):
 def get_project_page(api_key, url, page, list):
     log.info("Calling API page {page}".format(page=page))
     params = dict(private_token=api_key, per_page=100, page=page, membership='true')
-    r = web.get(url, params)
+    headers = {"PRIVATE-TOKEN": api_key}
+    r = web.get(url, params, headers=headers)
 
     # throw an error if request failed
     # Workflow will catch this and show it to the user


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22197568/94194094-c9821c00-fee3-11ea-868b-273baa138e56.png)
In the latest Gitlab API interface, you need to bring the Token into the headers to make the call.This solves my 403 problem.